### PR TITLE
Make `build` step optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ E.g.:
 - ensures that git repo last version is fetched
 - checks linting and tests by running `npm run test` command
 - does version bump, with `preid` if it is requested
-- builds all by `npm run build` command
+- builds all by running `npm run build` command
+  - If there is no `build` script, then `release-script` just skips the `build` step.
 - if one of `[rf|mt]-changelog` is used in 'devDependencies', then changelog is generated
 - adds and commits changed `package.json` (and `CHANGELOG.md`, if used) files to git repo
 - adds git tag with new version (and changelog message, if used)

--- a/src/release.js
+++ b/src/release.js
@@ -156,17 +156,21 @@ function release({ type, preid }) {
   safeRun('git add package.json');
 
   // npm run build
-  console.log('Running: '.cyan + 'build'.green);
-  const res = exec('npm run build');
-  if (res.code !== 0) {
-    // if error, then revert and exit
-    console.log('Build failed, reverting version bump'.red);
-    run('git reset HEAD .');
-    run('git checkout package.json');
-    console.log('Version bump reverted'.red);
-    printErrorAndExit(res.output);
+  if (npmjson.scripts.build) {
+    console.log('Running: '.cyan + 'build'.green);
+    const res = exec('npm run build');
+    if (res.code !== 0) {
+      // if error, then revert and exit
+      console.log('Build failed, reverting version bump'.red);
+      run('git reset HEAD .');
+      run('git checkout package.json');
+      console.log('Version bump reverted'.red);
+      printErrorAndExit(res.output);
+    }
+    console.log('Completed: '.cyan + 'build'.green);
+  } else {
+    console.log('There is no "build" script in package.json. Skipping this step.'.yellow);
   }
-  console.log('Completed: '.cyan + 'build'.green);
 
   const vVersion = `v${newVersion}`;
 


### PR DESCRIPTION
If there is no `build` script in package.json, then `release-script` just skips the `build` step.

Closes #2
