### PR TITLE
Only push once for both the commit and tags

### DIFF
--- a/src/release.js
+++ b/src/release.js
@@ -208,8 +208,7 @@ function release({ type, preid }) {
   } else {
     safeRun(`git tag -a --message="${versionAndNotes}" ${vVersion}`);
   }
-  safeRun('git push');
-  safeRun('git push --tags');
+  safeRun('git push --follow-tags');
   console.log('Tagged: '.cyan + vVersion.green);
 
   // publish to GitHub


### PR DESCRIPTION
This should eliminate the need to authenticate twice. My apologies if this inadvertantly breaks something else, I am making the PR using the github editor :P so can't test directly, but this is what I do when I do it by hand.
