### PR TITLE
Use 'docs-build' instead of 'build' for '--only-docs'

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ including `bower` publishing, for you - automatically.
 _Initial idea is got from `React-Bootstrap` release tools `./tools/release`,
 that have been written by [Matt Smith @mtscout6](https://github.com/mtscout6)_
 
-#### Publishing of built documents static pages
+#### Documents pages publishing
 
 If your project compiles static documentation pages (as e.g. `React-Boostrap` does)
 and needs to publish them to standalone repo / hosting (via `git push`),
@@ -71,7 +71,9 @@ this is as simple as:
 ```
 > release --only-docs
 ```
-In this case the `package.json` version will be bumped with `--preid docs` as `0.10.0` => `0.10.0-docs.0`
+In this case the `package.json` version will be bumped with `--preid docs` as `0.10.0` => `0.10.0-docs.0`.
+
+If `npm run docs-build` script is present, then it will be used instead of `npm run build` script.
 
 #### Pre-release versions publishing
 

--- a/src/release.js
+++ b/src/release.js
@@ -42,6 +42,7 @@ const bowerRepo = configOptions.bowerRepo; // if it is not set, then there is no
 const docsRoot = path.join(repoRoot, (configOptions.docsRoot || 'docs-built/'));
 const tmpDocsRepo = path.join(repoRoot, (configOptions.tmpDocsRepo || 'tmp-docs-repo'));
 const docsRepo = configOptions.docsRepo; // if it is not set, then there is no docs/site repo
+const docsBuild = npmjson.scripts && npmjson.scripts['docs-build'];
 
 const githubToken = process.env.GITHUB_TOKEN;
 
@@ -234,12 +235,18 @@ function release({ type, preid, npmTagName }) {
   console.log('Completed: '.cyan + '"npm run test"'.green);
 
   // npm run build
-  if (npmjson.scripts.build && !skipBuildStep) {
-    console.log('Running: '.cyan + 'build'.green);
-    runAndGitRevertOnError('npm run build');
-    console.log('Completed: '.cyan + 'build'.green);
+  if (argv.onlyDocs && docsBuild) {
+    console.log('Running: '.cyan + 'docs-build'.green);
+    runAndGitRevertOnError('npm run docs-build');
+    console.log('Completed: '.cyan + 'docs-build'.green);
   } else {
-    console.log('Skipping "npm run build" step.'.yellow);
+    if (npmjson.scripts.build && !skipBuildStep) {
+      console.log('Running: '.cyan + 'build'.green);
+      runAndGitRevertOnError('npm run build');
+      console.log('Completed: '.cyan + 'build'.green);
+    } else {
+      console.log('Skipping "npm run build" step.'.yellow);
+    }
   }
 
   const vVersion = `v${newVersion}`;


### PR DESCRIPTION
If `npm run docs-build` script is present, then it will be used instead of `npm run build` script
with `--only-docs` option.
